### PR TITLE
ci: update GitHub Actions workflows to use supported Node versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,12 +34,16 @@ jobs:
     if: github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' )
     steps:
     - uses: actions/checkout@v4
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
     - name: Cache node_modules
       id: cache-modules
       uses: actions/cache@v4
       with:
         path: node_modules
-        key: 12.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+        key: 22.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
     - name: Install
       if: steps.cache-modules.outputs.cache-hit != 'true'
       run: npm install


### PR DESCRIPTION
## Summary

Update deprecated Node versions in GitHub Actions workflows to use actively supported LTS and stable versions. Fixes failing CI/CD checks caused by using end-of-life Node versions.

## Problem

The GitHub Actions workflows were using deprecated Node versions:
- **coverage.yml**: Node 16.x (end-of-life since September 2023)
- **publish.yml**: Node 12.x (end-of-life since April 2022) + missing Node setup step

These outdated versions are no longer supported by GitHub Actions, causing workflow failures.

## Changes

### coverage.yml
- Updated Node version: **16.x → 20.x** (LTS, supported until April 2026)
- Coverage reports will now run on a stable, supported Node version

### publish.yml
- Added missing `actions/setup-node@v4` step (was completely absent)
- Set Node version: **22.x** (Current/stable, supported until October 2027)
- Fixed cache key from 12.x to 22.x to match the test job

### ci.yml
- Already using correct versions: **20.x and 22.x** ✅
- No changes needed

## Node Version Support

After this change, all workflows use actively supported versions:

| Workflow | Old Version | New Version | Status |
|----------|-------------|-------------|--------|
| ci.yml | 20.x, 22.x | 20.x, 22.x | ✅ No change needed |
| coverage.yml | 16.x | 20.x | ✅ Updated to LTS |
| publish.yml | 12.x | 22.x | ✅ Updated to current |

## Impact

- ✅ Fixes failing GitHub Actions workflows
- ✅ Uses actively supported Node versions
- ✅ Aligns with package.json requirements (20.x and 22.x)
- ✅ No changes to project code or dependencies
- ✅ Build and lint tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps coverage workflow to Node 20.x and updates publish workflow to use/setup Node 22.x with matching cache key.
> 
> - **GitHub Actions**:
>   - **coverage.yml**: Update matrix `node-version` from `16.x` to `20.x`.
>   - **publish.yml**:
>     - Add `actions/setup-node@v4` step to use `22.x` in the publish job.
>     - Update cache key from `12.x` to `22.x` to match the configured Node version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7472a8f4889e6775bc36698a6282a5371edad8f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->